### PR TITLE
fix missing monolog library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "craftcms/cms": "^3.1",
         "php": "^7.1",
-        "rollbar/rollbar": "^1.7"
+        "rollbar/rollbar": "^1.8.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fix for missing monolog library
![image](https://user-images.githubusercontent.com/16419586/117432861-bbd55000-af22-11eb-8081-c4cf7fc30ee9.png)
